### PR TITLE
update 330AWD Kit printer.cfg to use sw SPI and set bed max_power

### DIFF
--- a/Firmware/330AWD-printer.cfg
+++ b/Firmware/330AWD-printer.cfg
@@ -41,7 +41,7 @@ serial: /tmp/klipper_host_mcu
 ########################
 
 [stepper_x]
-##	in M3 position
+##  in M3 position
 step_pin: PE14
 dir_pin: PE8
 enable_pin: !PE9
@@ -55,7 +55,10 @@ position_max: 315
 homing_speed: 35  
 homing_retract_dist: 0
 [tmc5160 stepper_x] 
-spi_bus: spi1a 
+# spi_bus: spi1a
+spi_software_mosi_pin: PB5
+spi_software_miso_pin: PB4
+spi_software_sclk_pin: PB3
 cs_pin: PE7
 interpolate: false
 run_current: 1.75
@@ -65,7 +68,7 @@ driver_TOFF: 1
 
 
 [stepper_x1]
-##	in M5 position
+##  in M5 position
 step_pin: PE1
 dir_pin: PF0
 enable_pin: !PC15
@@ -73,7 +76,10 @@ rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200
 [tmc5160 stepper_x1] 
-spi_bus: spi1a
+# spi_bus: spi1a
+spi_software_mosi_pin: PB5
+spi_software_miso_pin: PB4
+spi_software_sclk_pin: PB3
 cs_pin: PF1
 interpolate: false
 run_current: 1.75
@@ -83,7 +89,7 @@ driver_TOFF: 1
 
 
 [stepper_y]
-##	in M4 position
+##  in M4 position
 step_pin: PE15
 dir_pin: PE11
 enable_pin: !PF2
@@ -97,7 +103,10 @@ position_max: 310
 homing_speed: 35  
 homing_retract_dist: 0
 [tmc5160 stepper_y] 
-spi_bus: spi1a
+# spi_bus: spi1a
+spi_software_mosi_pin: PB5
+spi_software_miso_pin: PB4
+spi_software_sclk_pin: PB3
 cs_pin: PE10
 interpolate: false
 run_current: 1.75
@@ -109,7 +118,7 @@ driver_TOFF: 1
 
 
 [stepper_y1]
-##	in M6 position
+##  in M6 position
 step_pin: PE0
 dir_pin: PG3
 enable_pin: !PG4
@@ -117,7 +126,10 @@ rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200 
 [tmc5160 stepper_y1] 
-spi_bus: spi1a
+# spi_bus: spi1a
+spi_software_mosi_pin: PB5
+spi_software_miso_pin: PB4
+spi_software_sclk_pin: PB3
 cs_pin: PG2
 interpolate: false
 run_current: 1.75
@@ -201,6 +213,7 @@ pid_Ki: 3.504
 pid_Kd: 317.878
 min_temp: 0
 max_temp: 130
+max_power: 0.6
 
 
 ########################
@@ -208,7 +221,7 @@ max_temp: 130
 ########################
 
 [fan]
-##	Print Cooling Fan - GPIO26
+##  Print Cooling Fan - GPIO26
 pin: rpi:gpio26
 max_power: 1
 cycle_time: 0.002
@@ -216,7 +229,7 @@ hardware_pwm: false
 shutdown_speed: 0
 
 [heater_fan hotend_fan]
-##	Hotend Fan - FAN0 Connector (or watercooling pump+fan on radiator)
+##  Hotend Fan - FAN0 Connector (or watercooling pump+fan on radiator)
 pin: PA0
 max_power: 1.0
 kick_start_time: 0.5
@@ -291,11 +304,11 @@ recover_velocity: 350
 pause_on_runout: true
 switch_pin: PA8
 runout_gcode:
-	G91
+    G91
     G1 E-30 F2500
-  	G90
-	G1 X0 Y0 F30000
-  	M104 S0
+    G90
+    G1 X0 Y0 F30000
+    M104 S0
 
 ########################
 ########################
@@ -340,7 +353,7 @@ shutdown_value:0
 
 ################################################################################################
 ################################################################################################
-#####				MACROS					
+#####               MACROS                  
 
 ##################
 [gcode_macro RETRACTION_UP]
@@ -363,57 +376,57 @@ gcode:
 #  SET_RETRACTION RETRACT_LENGTH={params.LENGTH|float}
 #  GET_RETRACTION
 
-########################	
+########################    
 [gcode_macro exhaustfan_on]
 gcode: 
-	SET_FAN_SPEED FAN=Exhaust_fan SPEED=1
-###	
-	
+    SET_FAN_SPEED FAN=Exhaust_fan SPEED=1
+### 
+    
 [gcode_macro exhaustfan_off]
 gcode: 
-	SET_FAN_SPEED FAN=Exhaust_fan SPEED=0
-	
-	
-###		
-	
+    SET_FAN_SPEED FAN=Exhaust_fan SPEED=0
+    
+    
+###     
+    
 [gcode_macro enclosurefan_on]
 gcode: 
-	SET_FAN_SPEED FAN=chamber_fan SPEED=1
+    SET_FAN_SPEED FAN=chamber_fan SPEED=1
 
-###			
-	
+###         
+    
 [gcode_macro enclosurefan_off]
 gcode: 
-	SET_FAN_SPEED FAN=chamber_fan SPEED=0
+    SET_FAN_SPEED FAN=chamber_fan SPEED=0
 
 
 [gcode_macro RSCS_on]
 gcode: 
-	SET_FAN_SPEED FAN=RSCS SPEED=1
-###	
-	
+    SET_FAN_SPEED FAN=RSCS SPEED=1
+### 
+    
 
 [gcode_macro RSCS_off]
 gcode: 
-	SET_FAN_SPEED FAN=RSCS SPEED=0
-		
+    SET_FAN_SPEED FAN=RSCS SPEED=0
+        
 ###
 
 [gcode_macro LED_on]
 gcode:
-	SET_PIN PIN=LED value=1   
+    SET_PIN PIN=LED value=1   
 
 
 [gcode_macro LED_off]
 gcode:
-	SET_PIN PIN=LED value=0  
+    SET_PIN PIN=LED value=0  
 
-###	
-	
+### 
+    
 [gcode_macro PA_tunning]
 gcode: 
-	SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=1 ACCEL=500
-	TUNING_TOWER COMMAND=SET_PRESSURE_ADVANCE PARAMETER=ADVANCE START=0 FACTOR=.005
+    SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=1 ACCEL=500
+    TUNING_TOWER COMMAND=SET_PRESSURE_ADVANCE PARAMETER=ADVANCE START=0 FACTOR=.005
 
 
 #####
@@ -423,7 +436,7 @@ gcode:
   {action_call_remote_method("set_device_power",
                              device="tplink",
                              state="off")}
-#####	
+#####   
 
 [gcode_macro TEST_RESONNANCES_X]
 gcode:
@@ -462,7 +475,7 @@ gcode:
     SET_VELOCITY_LIMIT ACCEL={accel} 
     SET_VELOCITY_LIMIT ACCEL_TO_DECEL={accel}
     G28
-	G1 Z5
+    G1 Z5
     G1 X{minX} Y{minY} F{speed} 
 
     {% for INTERVAL in range(steps) %}
@@ -475,9 +488,9 @@ gcode:
     {% endfor %}    
 
     RESTORE_GCODE_STATE NAME=accelltest_state 
-	
-	
-	
+    
+    
+    
 [gcode_macro ACCELL_TEST_Y]
 gcode:
 
@@ -496,7 +509,7 @@ gcode:
     SET_VELOCITY_LIMIT ACCEL={accel} 
     SET_VELOCITY_LIMIT ACCEL_TO_DECEL={accel}
     G28
-	G1 Z5
+    G1 Z5
     G1 X{minX} Y{minY} F{speed} 
 
     {% for INTERVAL in range(steps) %}


### PR DESCRIPTION
Updates the printer.cfg to use Software SPI to work around mcu timeouts experienced with the Fly 5160 v1.2 running Hardware SPI on Super8Pro board included in kits.

Also added `max_power: 0.6` for the bed heater and looks like my editor's linter cleaned up some whitespace