### PR TITLE
Add BOM/STL Readme w/ links & info

### DIFF
--- a/Assemblies BOM and STL/readme.md
+++ b/Assemblies BOM and STL/readme.md
@@ -1,5 +1,5 @@
 # Assembly BOM's and STL's
 
-This folder contains the BOM and STL files for each individual assembly specified in the CAD folder.
+This folder contains the BOM and STL files for each individual assembly specified in the [CAD](/CAD) folder.
 
 You can explore the folders for the assemblies you are interested in, or [download this folder](https://download-directory.github.io/?url=https://github.com/VzBoT3D/VzBoT-Vz330/tree/master/Assemblies%20BOM%20and%20STL) in full. (Powered by the "download-directory.github.io" tool.)

--- a/Assemblies BOM and STL/readme.md
+++ b/Assemblies BOM and STL/readme.md
@@ -2,7 +2,7 @@
 
 This folder contains the BOM and STL files for each individual assembly specified in the [CAD](/CAD) folder.
 
-You can explore the folders for the assemblies you are interested in, or [download this folder](https://download-directory.github.io/?url=https://github.com/VzBoT3D/VzBoT-Vz330/tree/master/Assemblies%20BOM%20and%20STL) in full. (Powered by the "download-directory.github.io" tool.)
+You can explore the folders for the assemblies you are interested in, or [download this folder](https://download-directory.github.io/?url=https://github.com/VzBoT3D/VzBoT-Vz330/tree/master/Assemblies%20BOM%20and%20STL) in full *(powered by the "download-directory.github.io" tool)*.
 
 ## Printing
 

--- a/Assemblies BOM and STL/readme.md
+++ b/Assemblies BOM and STL/readme.md
@@ -3,3 +3,11 @@
 This folder contains the BOM and STL files for each individual assembly specified in the [CAD](/CAD) folder.
 
 You can explore the folders for the assemblies you are interested in, or [download this folder](https://download-directory.github.io/?url=https://github.com/VzBoT3D/VzBoT-Vz330/tree/master/Assemblies%20BOM%20and%20STL) in full. (Powered by the "download-directory.github.io" tool.)
+
+## Printing
+
+Settings for printing can be found on the [Print settings](https://docs.vzbot.org/general/misc-info/print-settings/) VzBoT Docs page.
+
+The quantity of each printed part may differ. A selection of parts are available in different variants to suit the needs of more than one possible BOM or hardware setup. These are mostly supplied for retro-compatibility, and no longer recommended for new builds. New builds are encouraged to follow the standard BOM, like the Mellow3D kits. 
+
+Please carefully read through the filenames to assess whether the file or part applies to your machine or not. 

--- a/Assemblies BOM and STL/readme.md
+++ b/Assemblies BOM and STL/readme.md
@@ -1,0 +1,5 @@
+# Assembly BOM's and STL's
+
+This folder contains the BOM and STL files for each individual assembly specified in the CAD folder.
+
+You can explore the folders for the assemblies you are interested in, or [download this folder](https://download-directory.github.io/?url=https://github.com/VzBoT3D/VzBoT-Vz330/tree/master/Assemblies%20BOM%20and%20STL) in full. (Powered by the "download-directory.github.io" tool.)


### PR DESCRIPTION
Adds a readme file to the "Assemblies BOM and STL" folder.

The readme file has information about what the folder contains, a folder download link using an external tool (zips the folder up), and information about print settings and item quantity.

Use "Squash merge" when merging this PR.